### PR TITLE
Bug fixes, grapes and lib support

### DIFF
--- a/GroovyWrapper.groovy
+++ b/GroovyWrapper.groovy
@@ -1,31 +1,25 @@
 /**
-* from https://github.com/sdanzan/groovy-wrapper/blob/master/GroovyWrapper.groovy
-*
-* Ryan: missing features: if i missing, blows up in args
-* also, doesn't appear to add main class
- *
- *
 * Copyright 2002-2007 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
-        * You may obtain a copy of the License at
+* You may obtain a copy of the License at
 *
 *      http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-        * See the License for the specific language governing permissions and
+* See the License for the specific language governing permissions and
 * limitations under the License.
-        */
+*/
 
 /*
-        * Original script at http://groovy.codehaus.org/WrappingGroovyScript
+* Original script at http://groovy.codehaus.org/WrappingGroovyScript
 */
 
 /**
-        * Wrap a script and groovy jars to an executable jar
+* Wrap a script and groovy jars to an executable jar
 */
 def cli = new CliBuilder()
 cli.h( longOpt: 'help', required: false, 'show usage information' )
@@ -65,9 +59,14 @@ if (opt.c) {
 }
 
 def GROOVY_HOME = new File( System.getenv('GROOVY_HOME') )
-def HOME = new File(System.getenv('HOME'))
 if (!GROOVY_HOME.canRead() || GROOVY_HOME == "") {
     ant.echo( "Missing environment variable GROOVY_HOME: '${GROOVY_HOME}'" )
+    return
+}
+
+def HOME = new File(System.getProperty("user.home"))
+if (!HOME.canRead() || HOME == "") {
+    ant.echo( "Missing home directory(lib and grapes): '${HOME}'" )
     return
 }
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+#
+# Copyright 2002-2007 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# prefix assumed in script files
+prefix=/usr/local
+
+# files that need mode 755
+EXEC_FILES=groovyWrapper.sh
+
+#files that need mode 644
+SCRIPT_FILES =GroovyWrapper.groovy
+
+
+all:
+	@echo "usage: make install"
+	@echo "       make uninstall"
+
+check: GROOVY-EXISTS
+
+GROOVY-EXISTS: ; @which groovy > /dev/null
+
+install: check
+	install -d -m 0755 $(prefix)/bin
+	install -d -m 755 $(prefix)/share/groovy/lib
+	install -m 0755 $(EXEC_FILES) $(prefix)/bin
+	install -m 0644 $(SCRIPT_FILES) $(prefix)/share/groovy/lib
+
+uninstall:
+	test -d $(prefix)/bin && \
+	cd $(prefix)/bin && \
+	rm -f $(EXEC_FILES)
+
+	test -d $(prefix)/share/groovy/lib && \
+    cd $(prefix)/share/groovy/lib && \
+    rm -f $(SCRIPT_FILES)

--- a/README.md
+++ b/README.md
@@ -3,13 +3,17 @@ groovy-wrapper
 
 A modified version of the [GroovyWrapper script](http://groovy.codehaus.org/WrappingGroovyScript "Original GroovyWrapper script") 
 allowing passing multiple jars to be embedded in the final jar (thus creating
-an uberjar).
+an uberjar). 
+
+Further modified to support files in lib and grapes directory, following specific conventions
 
 Syntax is the same as the original script, plus two more options:
 
 * `-i` / `--include`: a list of jars to include in the destination jar
 * `-x`/ `--exclude`: a list of patterns matching files to exclude from the
   excluded jars
+* `-l`/ `--lib`: Include all from ~/.groovy/lib
+* `-g`/ `--grab`:  Include ~/.groovy/grapes from @Grab statements
 
 **Example:** `groovy GroovyWrapper.groovy -m Hello -c -i pretty-print.jar
 colors.jar -x 'META-INF/*.DSA'` will produce a `Hello.jar` including all the

--- a/groovyWrapper.bat
+++ b/groovyWrapper.bat
@@ -1,0 +1,6 @@
+@echo off
+REM ****************************************************************************************************
+REM assumed same directory, and groovy installed. See makefile and apply similar convention for windows
+REM ****************************************************************************************************
+
+groovy %~dp0/GroovyWrapper.groovy %*

--- a/groovyWrapper.sh
+++ b/groovyWrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+prefix=/usr/local
+
+groovy ${prefix}/share/groovy/lib/GroovyWrapper.groovy $@


### PR DESCRIPTION
The original version didn't quite work for me, but I liked the extensions so I did some bug fixes and others: 
- Added optional pull from ~/.groovy/lib
- Added optional pull from ~/.grapes (using @Grab symbol)
- Created Makefile for unix installs
- Added usable Windows .bat script

Full solution is probably a gradle plugin, but this is highly usable. 
